### PR TITLE
Update harbor setup for `yq` updates

### DIFF
--- a/bin/setup-harbor.sh
+++ b/bin/setup-harbor.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REGISTRY=$(yq r $PARAMS_YAML common.harborDomain)
+REGISTRY=$(yq e .common.harborDomain ${PARAMS_YAML})
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/build-service.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/catalog.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/petclinic.json
@@ -9,7 +9,7 @@ curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/proj
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/projects -H "Content-type: application/json" --data @harbor/project/policy.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/gcr.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/tac.json
-GITHUB_REGISTRY=$(jq -n --arg githubUser $(yq r $PARAMS_YAML common.githubUser) --arg githubToken $(yq r $PARAMS_YAML common.githubToken) "$(cat ./harbor/registry/github.json)")
+GITHUB_REGISTRY=$(jq -n --arg githubUser $(yq e .common.githubUser $PARAMS_YAML) --arg githubToken $(yq e .common.githubToken $PARAMS_YAML) "$(cat ./harbor/registry/github.json)")
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data "${GITHUB_REGISTRY}"
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/registries -H "Content-type: application/json" --data @harbor/registry/hub.json
 curl --user "admin:${HARBOR_PASSWORD}" -X POST https://${REGISTRY}/api/v2.0/replication/policies -H "Content-type: application/json" --data @harbor/replication/toolkit.json


### PR DESCRIPTION
TL;DR
-----

Fixes defect in harbor setup caused by `yq` update

Details
-------

Harbor setup was failing since `yq` updated to act more like `jq`.
This chagne fixes the `setup-harbor.sh` script to account for that.
